### PR TITLE
Fix for issue FLUME-2576

### DIFF
--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
@@ -313,7 +313,7 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
     }
 
     Context indexnameBuilderContext = new Context();
-    serializerContext.putAll(
+    indexnameBuilderContext.putAll(
             context.getSubProperties(INDEX_NAME_BUILDER_PREFIX));
 
     try {

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/test/java/org/apache/flume/sink/elasticsearch/TestElasticSearchSink.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/test/java/org/apache/flume/sink/elasticsearch/TestElasticSearchSink.java
@@ -401,6 +401,18 @@ public class TestElasticSearchSink extends AbstractElasticSearchSinkTest {
     assertTrue(fixture.getIndexNameBuilder() instanceof FakeIndexNameBuilder);
   }
 
+  @Test
+  public void shouldPassDateFormatToIndexNameBuilder() throws Exception {
+    Context context = new Context();
+    String dateFormat = "yyyy.MM.dd-HH";
+    context.put(ElasticSearchSinkConstants.INDEX_NAME_BUILDER_PREFIX + TimeBasedIndexNameBuilder.DATE_FORMAT,
+            dateFormat);
+
+    assertNull(fixture.getIndexNameBuilder());
+    fixture.configure(context);
+    assertEquals(((TimeBasedIndexNameBuilder) fixture.getIndexNameBuilder()).getFastDateFormat().getPattern(), dateFormat);
+  }
+
   public static class FakeConfigurable implements Configurable {
     @Override
     public void configure(Context arg0) {


### PR DESCRIPTION
IndexNameBuilder properties should be passed to indexnameBuilderContext and not to serializerContext in order to make the dateFormat and timeZone properties useable