### PR TITLE
Performance problems caused by too many small files!

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
@@ -258,6 +258,12 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
             candidateFiles.add(candidate.toFile());
           }
 
+          /* Start Edit by bright at 2017/08/30 Performance problems caused by too many small files!*/
+          if (candidateFiles.size() == 500) {
+            return FileVisitResult.TERMINATE;
+          }
+          /* End Edit by bright at 2017/08/30 Performance problems caused by too many small files!*/
+
           return FileVisitResult.CONTINUE;
         }
       });


### PR DESCRIPTION
I collect BLOB file by spooling directory source;
Every file is about 15KB and the total size of files is about 78GB。
As the number of files increases, more and more time is needed for function execution。